### PR TITLE
Actualized stepthrough

### DIFF
--- a/make_single_eltorito.c
+++ b/make_single_eltorito.c
@@ -1,11 +1,15 @@
 /*
 how to use
 
-1. place 32bitEFI.c and 64 bit linux iso into the same directory
-2. rename linux iso to blackmacbook64.iso
-3. compile 32bitEFI.c with "cc -g -Wall -o 32bitEFI.c"
-4. make it executable 'chmod +x 32bitEFI
-5. burn new iso
+1. Place 32bitEFI.c and 64 bit linux iso into the same directory
+2. Rename linux iso to blackmacbook64.iso
+3. Open a terminal and navigate into that folder, if you don't how to navigate file structure,
+  you should learn it is very easy. All you need are the "cd" command and the "pwd" command.
+4. Compile 32bitEFI.c with "cc -g -Wall -o 32bitEFI 32bitEFI.c" 
+4. Make it executable with "chmod +x 32bitEFI"
+5. Run the program that has just been compiled as "32bitEFI" (NOT 32bitEFI.c, this is the name of this C script)
+  with "./32bitEFI".
+5. Burn new iso
 */
 
 #include <sys/types.h>


### PR DESCRIPTION
There were some litlle mistakes in the c code comments that tell you the steps of this hack.
First, in step 3. write :

 "cc -g -Wall -o 32bitEFI 32bitEFI.c" 

(and  NOT "cc -g -Wall -o 32bitEFI.c" or you will get a fatal error : No input file)
Also when you run this command you should be IN the folder that contains both the code and the .iso.

Then before step 5 you should actually RUN the program that has just been compiled as "32bitEFI" (not 32bitEFI.c, this is your c script). 

In order to do that in the terminal, type "./32bitEFI". Now the iso has been modified and you shall burn it.